### PR TITLE
Update HasContentData trait with new content combination methods

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,8 @@ echo $response->text(); // [{"productName": "Tranquility Tea"}, {"productName": 
 ### Text and Local Image Input
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $data = base64_encode(file_get_contents('files/sample.jpg'));
 
 $response = $gemini->models()->generateContent([
@@ -82,6 +84,8 @@ echo $response->text(); // The image shows three people sitting in a waiting...
 ### Text and Uploaded File Input
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $fileUri = 'https://generativelanguage.googleapis.com/v1beta/files/jzqrgvbe36r0';
 
 $response = $gemini->models()->generateContent([
@@ -95,6 +99,8 @@ echo $response->text(); // The image shows a scene from a futuristic or sci-fi m
 ### Text and Local + Uploaded File Inputs
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $fileUri = 'https://generativelanguage.googleapis.com/v1beta/files/s7ycnqb6f06n'; // the banner image
 $blob = base64_encode(file_get_contents('files/sample.png'));
 
@@ -112,6 +118,8 @@ echo $response->text(); // The first image shows a still life featuring a plate 
 ### Text and Multiple Local File Inputs
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $blobs = [
     [
         'mimeType' => 'image/jpeg',
@@ -134,6 +142,8 @@ echo $response->text(); // The first image is a promotional image for the Gemini
 ### Text and Multiple Uploaded File Inputs
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $files = [
     [
         'fileUri' => 'https://generativelanguage.googleapis.com/v1beta/files/s7ycnqb6f06n',
@@ -156,6 +166,8 @@ echo $response->text(); // The first image is a poster for a product called "Gem
 ### Text and Multiple Local + Uploaded File Inputs
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $blobs = [
     [
         'mimeType' => 'image/jpeg',
@@ -192,6 +204,8 @@ echo $response->text(); // The first image is a screenshot of a Google...
 ### Multi-turn Conversations (Chat)
 
 ```php
+use Derrickob\GeminiApi\Data\Content;
+
 $response = $gemini->models()->generateContent([
     'model' => 'models/gemini-1.5-flash',
     'contents' => [

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,22 @@
 # Additional Examples
+NOTE: This page only covers additional examples not already available on the main README page.
+
+<!-- TOC -->
+* [Additional Examples](#additional-examples)
+  * [Code Execution](#code-execution)
+  * [JSON Mode](#json-mode)
+  * [Chat Resource](#chat-resource)
+    * [Text and Local Image Input](#text-and-local-image-input)
+    * [Text and Uploaded File Input](#text-and-uploaded-file-input)
+    * [Text and Local + Uploaded File Inputs](#text-and-local--uploaded-file-inputs)
+    * [Text and Multiple Local File Inputs](#text-and-multiple-local-file-inputs)
+    * [Text and Multiple Uploaded File Inputs](#text-and-multiple-uploaded-file-inputs)
+    * [Text and Multiple Local + Uploaded File Inputs](#text-and-multiple-local--uploaded-file-inputs)
+    * [Multi-turn Conversations (Chat)](#multi-turn-conversations-chat)
+  * [Function Calling](#function-calling)
+    * [Request](#request)
+    * [Submit Function Call Response](#submit-function-call-response)
+<!-- TOC -->
 
 ## Code Execution
 
@@ -44,6 +62,146 @@ $response = $gemini->models()->generateContent([
 ]);
 
 echo $response->text(); // [{"productName": "Tranquility Tea"}, {"productName": "Golden Hour Brew"}, {"productName": "Serene Sip"}, {"productName": "Zenith Infusion"}, {"productName": "Midnight Bloom"}]
+```
+
+## Chat Resource
+
+### Text and Local Image Input
+
+```php
+$data = base64_encode(file_get_contents('files/sample.jpg'));
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => Content::createTextWithBlobContent('What\'s in this image?', 'image/jpeg', $data, 'user'),
+]);
+
+echo $response->text(); // The image shows three people sitting in a waiting...
+```
+
+### Text and Uploaded File Input
+
+```php
+$fileUri = 'https://generativelanguage.googleapis.com/v1beta/files/jzqrgvbe36r0';
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => Content::createTextWithFileContent('What\'s in this image?', $fileUri, 'image/jpeg', 'user'),
+]);
+
+echo $response->text(); // The image shows a scene from a futuristic or sci-fi movie...
+```
+
+### Text and Local + Uploaded File Inputs
+
+```php
+$fileUri = 'https://generativelanguage.googleapis.com/v1beta/files/s7ycnqb6f06n'; // the banner image
+$blob = base64_encode(file_get_contents('files/sample.png'));
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => [
+        Content::createTextContent('Analyze these files and describe them for me', 'user'),
+        Content::createBlobWithFileContent('image/png', $blob, $fileUri, 'image/jpeg', 'user'),
+    ],
+]);
+
+echo $response->text(); // The first image shows a still life featuring a plate of blueberry...
+```
+
+### Text and Multiple Local File Inputs
+
+```php
+$blobs = [
+    [
+        'mimeType' => 'image/jpeg',
+        'data' => base64_encode(file_get_contents('files/banner.jpeg')),
+    ],
+    [
+        'mimeType' => 'image/png',
+        'data' => base64_encode(file_get_contents('files/sample.png')),
+    ],
+];
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => Content::createTextWithBlobsContent('What are these images?', $blobs, 'user'),
+]);
+
+echo $response->text(); // The first image is a promotional image for the Gemini AI platform, which...
+```
+
+### Text and Multiple Uploaded File Inputs
+
+```php
+$files = [
+    [
+        'fileUri' => 'https://generativelanguage.googleapis.com/v1beta/files/s7ycnqb6f06n',
+        'mimeType' => 'image/jpeg',
+    ],
+    [
+        'fileUri' => 'https://generativelanguage.googleapis.com/v1beta/files/jzqrgvbe36r0',
+        'mimeType' => 'image/jpeg',
+    ],
+];
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => Content::createTextWithFilesContent('What can you see?', $files, 'user'),
+]);
+
+echo $response->text(); // The first image is a poster for a product called "Gemini," which...
+```
+
+### Text and Multiple Local + Uploaded File Inputs
+
+```php
+$blobs = [
+    [
+        'mimeType' => 'image/jpeg',
+        'data' => base64_encode(file_get_contents('files/banner.jpeg')),
+    ],
+    [
+        'mimeType' => 'image/png',
+        'data' => base64_encode(file_get_contents('files/sample.png')),
+    ],
+];
+
+$files = [
+    [
+        'fileUri' => 'https://generativelanguage.googleapis.com/v1beta/files/s7ycnqb6f06n',
+        'mimeType' => 'image/jpeg',
+    ],
+    [
+        'fileUri' => 'https://generativelanguage.googleapis.com/v1beta/files/jzqrgvbe36r0',
+        'mimeType' => 'image/jpeg',
+    ],
+];
+
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => [
+        Content::createTextContent('What can you see in these provided files?', 'user'),
+        Content::createBlobsAndFilesContent($blobs, $files, 'user'),
+    ],
+]);
+
+echo $response->text(); // The first image is a screenshot of a Google...
+```
+
+### Multi-turn Conversations (Chat)
+
+```php
+$response = $gemini->models()->generateContent([
+    'model' => 'models/gemini-1.5-flash',
+    'contents' => [
+        Content::createTextContent('Write the first line of a story about a magic backpack.', 'user'),
+        Content::createTextContent('In the bustling city of Meadow brook, lived a young girl named Sophie. She was a bright and curious soul with an imaginative mind.', 'model'),
+        Content::createTextContent('Can you set it in a quiet village in 1600s France?', 'user'),
+    ],
+]);
+
+echo $response->text(); // The worn leather of the backpack creaked softly as Marie, a young girl...
 ```
 
 ## Function Calling

--- a/src/Exceptions/ApiRequestException.php
+++ b/src/Exceptions/ApiRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Derrickob\GeminiApi\Exceptions;
 
 use Saloon\Exceptions\Request\RequestException;

--- a/src/Traits/Data/HasContentData.php
+++ b/src/Traits/Data/HasContentData.php
@@ -24,7 +24,7 @@ trait HasContentData
 
     public static function createBlobContent(string $mimeType, string $data, ?string $role = null): Content
     {
-        $role = Role::from(strtolower((string) $role));
+        $role = Role::from(strtolower((string)$role));
 
         return new Content([self::createBlobPart($mimeType, $data)], $role);
     }
@@ -54,6 +54,68 @@ trait HasContentData
             self::createTextPart($text),
             self::createFilePart($fileUri, $mimeType),
         ], $role);
+    }
+
+    public static function createBlobWithFileContent(string $blobMimeType, string $blobData, string $fileUri, ?string $fileMimeType = null, ?string $role = null): Content
+    {
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
+
+        return new Content([
+            self::createBlobPart($blobMimeType, $blobData),
+            self::createFilePart($fileUri, $fileMimeType),
+        ], $role);
+    }
+
+    public static function createTextWithBlobsContent(string $text, array $blobs, ?string $role = null): Content
+    {
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
+        $parts = [self::createTextPart($text)];
+
+        foreach ($blobs as $blob) {
+            if (!isset($blob['mimeType']) || !isset($blob['data'])) {
+                throw new InvalidArgumentException('Each blob must have mimeType and data');
+            }
+            $parts[] = self::createBlobPart($blob['mimeType'], $blob['data']);
+        }
+
+        return new Content($parts, $role);
+    }
+
+    public static function createTextWithFilesContent(string $text, array $files, ?string $role = null): Content
+    {
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
+        $parts = [self::createTextPart($text)];
+
+        foreach ($files as $file) {
+            if (!isset($file['fileUri'])) {
+                throw new InvalidArgumentException('Each file must have fileUri');
+            }
+            $parts[] = self::createFilePart($file['fileUri'], $file['mimeType'] ?? null);
+        }
+
+        return new Content($parts, $role);
+    }
+
+    public static function createBlobsAndFilesContent(array $blobs, array $files, ?string $role = null): Content
+    {
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
+        $parts = [];
+
+        foreach ($blobs as $blob) {
+            if (!isset($blob['mimeType']) || !isset($blob['data'])) {
+                throw new InvalidArgumentException('Each blob must have mimeType and data');
+            }
+            $parts[] = self::createBlobPart($blob['mimeType'], $blob['data']);
+        }
+
+        foreach ($files as $file) {
+            if (!isset($file['fileUri'])) {
+                throw new InvalidArgumentException('Each file must have fileUri');
+            }
+            $parts[] = self::createFilePart($file['fileUri'], $file['mimeType'] ?? null);
+        }
+
+        return new Content($parts, $role);
     }
 
     public static function parseContents(mixed $contents): array

--- a/src/Traits/Data/HasContentData.php
+++ b/src/Traits/Data/HasContentData.php
@@ -38,16 +38,22 @@ trait HasContentData
 
     public static function createTextWithBlobContent(string $text, string $mimeType, string $data, ?string $role = null): Content
     {
-        $role = Role::from(strtolower((string) $role));
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
 
-        return new Content([self::createTextWithBlobPart($text, $mimeType, $data)], $role);
+        return new Content([
+            self::createTextPart($text),
+            self::createBlobPart($mimeType, $data),
+        ], $role);
     }
 
     public static function createTextWithFileContent(string $text, string $fileUri, ?string $mimeType = null, ?string $role = null): Content
     {
-        $role = Role::from(strtolower((string) $role));
+        $role = isset($role) ? Role::from(strtolower($role)) : null;
 
-        return new Content([self::createTextWithFilePart($text, $fileUri, $mimeType)], $role);
+        return new Content([
+            self::createTextPart($text),
+            self::createFilePart($fileUri, $mimeType),
+        ], $role);
     }
 
     public static function parseContents(mixed $contents): array

--- a/src/Traits/Data/HasPartData.php
+++ b/src/Traits/Data/HasPartData.php
@@ -29,18 +29,4 @@ trait HasPartData
 
         return new Part(fileData: new FileData(fileUri: $fileUri, mimeType: $mimeType));
     }
-
-    public static function createTextWithBlobPart(string $text, string $mimeType, string $data): Part
-    {
-        $mimeType = MimeType::from(strtolower($mimeType));
-
-        return new Part(text: $text, inlineData: new Blob($mimeType, $data));
-    }
-
-    public static function createTextWithFilePart(string $text, string $fileUri, ?string $mimeType = null): Part
-    {
-        $mimeType = isset($mimeType) ? MimeType::from(strtolower($mimeType)) : null;
-
-        return new Part(text: $text, fileData: new FileData(fileUri: $fileUri, mimeType: $mimeType));
-    }
 }


### PR DESCRIPTION
This PR introduces the following changes:

1. **Updated `HasContentData` trait**:
   - Added new methods to create content with various combinations of text, blobs, and files:
     - `createBlobWithFileContent`
     - `createTextWithBlobsContent`
     - `createTextWithFilesContent`
     - `createBlobsAndFilesContent`
   - These new methods provide more flexibility in constructing the various content types.

2. **Removed unused blob and file methods from the `HasPartData` trait**:
   - The `HasPartData` trait previously had methods to create invalid blob and file content, which have now been removed.
   - This change may be a breaking update for users who were relying on these invalid methods.

3. **Updated `ApiRequestException` exception class** by declaring strict types.
4. **Added more examples**